### PR TITLE
Stale references

### DIFF
--- a/src/main/java/com/softserve/edu/greencity/ui/locators/EcoNewsPageLocator.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/locators/EcoNewsPageLocator.java
@@ -27,7 +27,7 @@ public enum EcoNewsPageLocator implements Locator {
     GALLERY_VIEW_WRAPPER(By.cssSelector(".gallery-view-active.list")),
     LIST_VIEW_BUTTON(By.cssSelector("div.list-view")),
     LIST_VIEW_BUTTON_COMPONENT(By.cssSelector("div.list-view > div")),
-    LIST_VIEW_WRAPPER(By.cssSelector(".list-view-li-active")),
+    LIST_VIEW_WRAPPER(By.cssSelector(".list-view")),
     OPEN_TOPICS_TAGS(By.cssSelector("div.tags>div.tags-item")),
     NEWS_TITLE(By.cssSelector("div.news-title")),
     NEWS_INFO_DATE(By.cssSelector("div.news-info>div.news-info-date")),

--- a/src/main/java/com/softserve/edu/greencity/ui/pages/econews/EcoNewsPage.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/pages/econews/EcoNewsPage.java
@@ -166,7 +166,7 @@ public class EcoNewsPage extends TopPart {
             driver.findElement(LIST_VIEW_WRAPPER.getPath()).isDisplayed();
             return true;
         }
-        catch (org.openqa.selenium.NoSuchElementException e){
+        catch (NoSuchElementException | TimeoutException e){
             return false;
         }
     }

--- a/src/main/java/com/softserve/edu/greencity/ui/pages/econews/EcoNewsPage.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/pages/econews/EcoNewsPage.java
@@ -47,6 +47,12 @@ public class EcoNewsPage extends TopPart {
     }
 
     private void checkElements() {
+        checkNewsDisplayed();
+        waitsSwitcher.setExplicitWait(5, ExpectedConditions.visibilityOf(getGridView()));
+        waitsSwitcher.setExplicitWait(5, ExpectedConditions.visibilityOf(getListView()));
+    }
+
+    private void checkNewsDisplayed() {
         WebElement firstItem = driver.findElement(DISPLAYED_ARTICLES.getPath());
         try {
             waitsSwitcher.setExplicitWait(2, ExpectedConditions.stalenessOf(firstItem));
@@ -55,8 +61,6 @@ public class EcoNewsPage extends TopPart {
             ; //Everything is OK
         }
         waitsSwitcher.setExplicitWait(10, ExpectedConditions.presenceOfAllElementsLocatedBy(DISPLAYED_ARTICLES.getPath()));
-        waitsSwitcher.setExplicitWait(5, ExpectedConditions.visibilityOf(getGridView()));
-        waitsSwitcher.setExplicitWait(5, ExpectedConditions.visibilityOf(getListView()));
     }
 
     public List<WebElement> getTopicsInPage() {
@@ -293,7 +297,7 @@ public class EcoNewsPage extends TopPart {
     @Step("Switch to grid view")
     public EcoNewsPage switchToGridView() {
         clickGridView();
-        checkElements();
+        checkNewsDisplayed();
         return new EcoNewsPage(driver);
     }
 
@@ -306,7 +310,7 @@ public class EcoNewsPage extends TopPart {
     public EcoNewsPage switchToListView() {
         if(isListViewPresent()){
         clickListView();}
-        checkElements();
+        checkNewsDisplayed();
         return this;
     }
 

--- a/src/main/java/com/softserve/edu/greencity/ui/pages/econews/EcoNewsPage.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/pages/econews/EcoNewsPage.java
@@ -150,7 +150,7 @@ public class EcoNewsPage extends TopPart {
     @Step("Check if list view is active")
     public boolean isActiveListView() {
         try{
-            waitsSwitcher.setExplicitWaitWithStaleReferenceWrap(3,
+            waitsSwitcher.setExplicitWait(3,
                     ExpectedConditions.presenceOfElementLocated(LIST_VIEW_WRAPPER.getPath()));
             driver.findElement(LIST_VIEW_WRAPPER.getPath()).isDisplayed();
             return true;
@@ -472,7 +472,7 @@ public class EcoNewsPage extends TopPart {
 
     @Step
     public List<WebElement> getDisplayedArticles() {
-        return waitsSwitcher.setExplicitWaitWithStaleReferenceWrap(10,
+        return waitsSwitcher.setExplicitWait(10,
                 ExpectedConditions.visibilityOfAllElementsLocatedBy(DISPLAYED_ARTICLES.getPath()));
     }
 

--- a/src/main/java/com/softserve/edu/greencity/ui/pages/econews/EcoNewsPage.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/pages/econews/EcoNewsPage.java
@@ -43,13 +43,20 @@ public class EcoNewsPage extends TopPart {
 
     public EcoNewsPage(WebDriver driver) {
         super(driver);
-        //checkElements();
+        checkElements();
     }
 
     private void checkElements() {
+        WebElement firstItem = driver.findElement(DISPLAYED_ARTICLES.getPath());
+        try {
+            waitsSwitcher.setExplicitWait(2, ExpectedConditions.stalenessOf(firstItem));
+            logger.warn("The site performed the same GET request twice and redrew page");
+        } catch (TimeoutException error) {
+            ; //Everything is OK
+        }
         waitsSwitcher.setExplicitWait(10, ExpectedConditions.presenceOfAllElementsLocatedBy(DISPLAYED_ARTICLES.getPath()));
-        waitsSwitcher.setExplicitWait(10, ExpectedConditions.visibilityOf(getGridView()));
-        waitsSwitcher.setExplicitWait(10, ExpectedConditions.visibilityOf(getListView()));
+        waitsSwitcher.setExplicitWait(5, ExpectedConditions.visibilityOf(getGridView()));
+        waitsSwitcher.setExplicitWait(5, ExpectedConditions.visibilityOf(getListView()));
     }
 
     public List<WebElement> getTopicsInPage() {
@@ -201,7 +208,7 @@ public class EcoNewsPage extends TopPart {
     @Step("Get items container")
     public ItemsContainer getItemsContainer() {
         // TODO add here some waiter for uploading news
-        waitsSwitcher.setExplicitWait(
+        waitsSwitcher.setExplicitWait(5,
                 ExpectedConditions.presenceOfAllElementsLocatedBy(DISPLAYED_ARTICLES.getPath()));
         return new ItemsContainer(driver);
     }
@@ -286,6 +293,7 @@ public class EcoNewsPage extends TopPart {
     @Step("Switch to grid view")
     public EcoNewsPage switchToGridView() {
         clickGridView();
+        checkElements();
         return new EcoNewsPage(driver);
     }
 
@@ -298,6 +306,7 @@ public class EcoNewsPage extends TopPart {
     public EcoNewsPage switchToListView() {
         if(isListViewPresent()){
         clickListView();}
+        checkElements();
         return this;
     }
 
@@ -472,7 +481,7 @@ public class EcoNewsPage extends TopPart {
 
     @Step
     public List<WebElement> getDisplayedArticles() {
-        return waitsSwitcher.setExplicitWait(10,
+        return waitsSwitcher.setExplicitWaitWithStaleReferenceWrap(10,
                 ExpectedConditions.visibilityOfAllElementsLocatedBy(DISPLAYED_ARTICLES.getPath()));
     }
 

--- a/src/main/java/com/softserve/edu/greencity/ui/pages/econews/ItemComponent.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/pages/econews/ItemComponent.java
@@ -4,10 +4,13 @@ import com.softserve.edu.greencity.ui.data.econews.Tag;
 import  static com.softserve.edu.greencity.ui.locators.ItemComponentLocators.*;
 
 import com.softserve.edu.greencity.ui.tools.engine.WaitsSwitcher;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -69,7 +72,7 @@ public final class ItemComponent {
 
     //Title
     public WebElement getTitle() {
-        waitsSwitcher.setExplicitWait(5,
+        waitsSwitcher.setExplicitWaitWithStaleReferenceWrap(5,
                 ExpectedConditions.visibilityOfElementLocated(TITLE.getPath()));
         return newsItem.findElement(TITLE.getPath());
     }
@@ -217,13 +220,24 @@ public final class ItemComponent {
      * @return
      */
     public boolean areTagsPresent(List<Tag> tags) {
-        for (WebElement actualTag : getTags()) {
-            for (Tag tagToCheck : tags) {
-                if (actualTag.getText().equalsIgnoreCase(tagToCheck.toString())) {
-                    return true;
+        Logger logger = LoggerFactory.getLogger("ItemComponent");
+        int trialsLeft = 5;
+        do {
+            try {
+                for (WebElement actualTag : getTags()) {
+                    for (Tag tagToCheck : tags) {
+                        if (actualTag.getText().equalsIgnoreCase(tagToCheck.toString())) {
+                            return true;
+                        }
+                    }
                 }
+                return false;
+            } catch (StaleElementReferenceException error) {
+                logger.warn("StaleElementReferenceException caught, retrying...");
+                WaitsSwitcher.sleep(100);
             }
-        }
+            trialsLeft--;
+        } while (trialsLeft > 0);
         return false;
     }
 }

--- a/src/main/java/com/softserve/edu/greencity/ui/pages/econews/ItemComponent.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/pages/econews/ItemComponent.java
@@ -51,7 +51,7 @@ public final class ItemComponent {
     }
 
     public WebElement getTagsContainer() {
-        waitsSwitcher.setExplicitWaitWithStaleReferenceWrap(5,
+        waitsSwitcher.setExplicitWait(5,
                 ExpectedConditions.visibilityOfElementLocated(TAGS_CONTAINER.getPath()));
         return findFromItemWithStaleReferenceWrap(TAGS_CONTAINER);
     }
@@ -86,7 +86,7 @@ public final class ItemComponent {
 
     //Title
     public WebElement getTitle() {
-        waitsSwitcher.setExplicitWaitWithStaleReferenceWrap(5,
+        waitsSwitcher.setExplicitWait(5,
                 ExpectedConditions.visibilityOfElementLocated(TITLE.getPath()));
         return findFromItemWithStaleReferenceWrap(TITLE);
     }
@@ -262,6 +262,7 @@ public final class ItemComponent {
             } catch (StaleElementReferenceException error) {
                 logger.warn("StaleElementReferenceException caught, retrying...");
                 WaitsSwitcher.sleep(100);
+                //TODO need somehow to refresh the newsItem...
             }
             retriesLeft--;
         } while (retriesLeft > 0);

--- a/src/main/java/com/softserve/edu/greencity/ui/pages/econews/ItemsContainer.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/pages/econews/ItemsContainer.java
@@ -59,6 +59,7 @@ public class ItemsContainer implements StableWebElementSearch {
 
     private List<WebElement> getItems() {
         WaitsSwitcher waitsSwitcher = new WaitsSwitcher(driver);
+        /*
         WebElement firstItem = driver.findElement(items);
         try {
             waitsSwitcher.setExplicitWait(2, ExpectedConditions.stalenessOf(firstItem));
@@ -66,6 +67,7 @@ public class ItemsContainer implements StableWebElementSearch {
         } catch (TimeoutException error) {
             ; //Everything is OK
         }
+        */
 
         return waitsSwitcher.setExplicitWait(5,
                 ExpectedConditions.presenceOfAllElementsLocatedBy(items));

--- a/src/main/java/com/softserve/edu/greencity/ui/pages/econews/ItemsContainer.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/pages/econews/ItemsContainer.java
@@ -8,10 +8,7 @@ import com.softserve.edu.greencity.ui.tools.engine.StableWebElementSearch;
 import static com.softserve.edu.greencity.ui.locators.EcoNewsPageLocator.*;
 
 import com.softserve.edu.greencity.ui.tools.engine.WaitsSwitcher;
-import org.openqa.selenium.By;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
+import org.openqa.selenium.*;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.slf4j.Logger;
@@ -61,9 +58,16 @@ public class ItemsContainer implements StableWebElementSearch {
     }
 
     private List<WebElement> getItems() {
-        //The site performs the same GET request twice and redraws page, so StaleElementReferences appear
         WaitsSwitcher waitsSwitcher = new WaitsSwitcher(driver);
-        return waitsSwitcher.setExplicitWaitWithStaleReferenceWrap(5,
+        WebElement firstItem = driver.findElement(items);
+        try {
+            waitsSwitcher.setExplicitWait(2, ExpectedConditions.stalenessOf(firstItem));
+            logger.warn("The site performed the same GET request twice and redrew page");
+        } catch (TimeoutException error) {
+            ; //Everything is OK
+        }
+
+        return waitsSwitcher.setExplicitWait(5,
                 ExpectedConditions.presenceOfAllElementsLocatedBy(items));
     }
 

--- a/src/main/java/com/softserve/edu/greencity/ui/pages/econews/ItemsContainer.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/pages/econews/ItemsContainer.java
@@ -39,17 +39,24 @@ public class ItemsContainer implements StableWebElementSearch {
     }
 
     private void checkElements() {
-        itemComponents = new ArrayList<>();
-        for (WebElement current : getItems()) {
-            itemComponents.add(new ItemComponent(driver, current));
-        }
+        getItemComponents();
     }
 
     private List<ItemComponent> getItemComponents() {
         itemComponents = new ArrayList<>();
-        for (WebElement current : getItems()) {
-            itemComponents.add(new ItemComponent(driver, current));
-        }
+        int retriesLeft = 5;
+        do {
+            try {
+                for (WebElement current : getItems()) {
+                    itemComponents.add(new ItemComponent(driver, current));
+                }
+            } catch (StaleElementReferenceException error) {
+                logger.warn("StaleElementReferenceException caught, retrying...");
+                WaitsSwitcher.sleep(100);
+            }
+            retriesLeft--;
+        } while (retriesLeft > 0);
+
         return itemComponents;
     }
 

--- a/src/main/java/com/softserve/edu/greencity/ui/pages/econews/ItemsContainer.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/pages/econews/ItemsContainer.java
@@ -9,6 +9,7 @@ import static com.softserve.edu.greencity.ui.locators.EcoNewsPageLocator.*;
 
 import com.softserve.edu.greencity.ui.tools.engine.WaitsSwitcher;
 import org.openqa.selenium.By;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -53,8 +54,9 @@ public class ItemsContainer implements StableWebElementSearch {
     }
 
     private List<WebElement> getItems() {
+        //The site performs the same GET request twice and redraws page, so StaleElementReferences appear
         WaitsSwitcher waitsSwitcher = new WaitsSwitcher(driver);
-        return waitsSwitcher.setExplicitWait(7,
+        return waitsSwitcher.setExplicitWaitWithStaleReferenceWrap(5,
                 ExpectedConditions.presenceOfAllElementsLocatedBy(items));
     }
 

--- a/src/main/java/com/softserve/edu/greencity/ui/tools/engine/WaitsSwitcher.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/tools/engine/WaitsSwitcher.java
@@ -89,6 +89,7 @@ public final class WaitsSwitcher {
     /**
      * The site performs the same GET request twice and redraws page, so StaleElementReferences appear
      * This method retries the explicit search several times
+     * No sense to use it with the conditions that re-locate an element
      */
     public <V> V setExplicitWaitWithStaleReferenceWrap(long seconds, Function<? super WebDriver, V> expectedCondition,
                                                        int retries) {

--- a/src/test/java/com/softserve/edu/greencity/ui/assertions/EcoNewsTagsAssertion.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/assertions/EcoNewsTagsAssertion.java
@@ -9,9 +9,12 @@ import java.util.List;
 public class EcoNewsTagsAssertion {
     public static void assertNewsFilteredByTags(ItemsContainer news, List<Tag> tags) {
         boolean newFilteredCorrectly = true;
-        for(int i = 0; i < news.getItemComponentsCount(); i++) {
+        int newsCount = news.getItemComponentsCount();
+        for(int i = 0; i < newsCount; i++) {
+            System.out.println("i = " + i);
             if(!news.chooseNewsByNumber(i).areTagsPresent(tags)) {
                 newFilteredCorrectly = false;
+                break;
             }
         }
         Assert.assertTrue(newFilteredCorrectly);

--- a/src/test/java/com/softserve/edu/greencity/ui/tests/runner/GreenCityTestRunner.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/tests/runner/GreenCityTestRunner.java
@@ -82,7 +82,6 @@ public abstract class GreenCityTestRunner {
         }
         driver.manage().timeouts().implicitlyWait(5, TimeUnit.SECONDS);
         driver.manage().timeouts().pageLoadTimeout(65, TimeUnit.SECONDS);
-        driver.manage().window().maximize();
         /*<============================Locale============================>*/
     }
 
@@ -95,6 +94,7 @@ public abstract class GreenCityTestRunner {
 
     @BeforeMethod
     public void setUp() {
+        driver.manage().window().maximize();
         driver.get(BASE_URL);
         softAssert = new SoftAssert();
     }

--- a/src/test/java/com/softserve/edu/greencity/ui/tests/viewallnews/EcoNewsGridViewTest.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/tests/viewallnews/EcoNewsGridViewTest.java
@@ -91,7 +91,7 @@ public class EcoNewsGridViewTest extends GreenCityTestRunner {
         softAssert.assertAll();
     }
 
-    @Test(retryAnalyzer = RetryAnalyzerImpl.class)
+    @Test
     @Description("GC-666")
     public void datePxLengthTest() {
         logger.info("Date px length test");
@@ -281,7 +281,7 @@ public class EcoNewsGridViewTest extends GreenCityTestRunner {
         econewsPage.isArticleTextContentDisplayed(elements);
     }
 
-    @Test(retryAnalyzer = RetryAnalyzerImpl.class)
+    @Test
     @Description("Verify that at least text content displayed in each article displayed GC-337")
     public void chronologicalNewsTest() {
         logger.info("ChronologicalNewsTest");

--- a/src/test/java/com/softserve/edu/greencity/ui/tests/viewallnews/EcoNewsGridViewTest.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/tests/viewallnews/EcoNewsGridViewTest.java
@@ -11,10 +11,7 @@ import com.softserve.edu.greencity.ui.tools.jdbc.services.EcoNewsService;
 import io.qameta.allure.Description;
 import org.openqa.selenium.WebElement;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.testng.annotations.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -221,6 +218,7 @@ public class EcoNewsGridViewTest extends GreenCityTestRunner {
         }
     }
 
+    @Ignore //runs too long
     @Test
     @Description("GC-674")
     public void newsAligningTest() {

--- a/src/test/java/com/softserve/edu/greencity/ui/tests/viewallnews/EcoNewsGridViewTest.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/tests/viewallnews/EcoNewsGridViewTest.java
@@ -2,11 +2,13 @@ package com.softserve.edu.greencity.ui.tests.viewallnews;
 
 import com.softserve.edu.greencity.ui.data.User;
 import com.softserve.edu.greencity.ui.data.UserRepository;
+import com.softserve.edu.greencity.ui.data.econews.NewsData;
 import com.softserve.edu.greencity.ui.data.econews.NewsDataRepository;
 import com.softserve.edu.greencity.ui.pages.econews.EcoNewsPage;
 import com.softserve.edu.greencity.ui.pages.econews.ItemComponent;
 import com.softserve.edu.greencity.ui.tests.runner.GreenCityTestRunner;
 import com.softserve.edu.greencity.ui.tests.runner.RetryAnalyzerImpl;
+import com.softserve.edu.greencity.ui.tools.jdbc.dao.EcoNewsDao;
 import com.softserve.edu.greencity.ui.tools.jdbc.services.EcoNewsService;
 import io.qameta.allure.Description;
 import org.openqa.selenium.WebElement;
@@ -118,7 +120,7 @@ public class EcoNewsGridViewTest extends GreenCityTestRunner {
             ecoNewsPage.changeWindowWidth(integer);
             ecoNewsPage.countNewsColumns(integer);
         }
-        softAssert.assertAll();
+        softAssert.assertAll(); //Asserts are hidden in countNewsColumns
     }
 
 
@@ -178,18 +180,22 @@ public class EcoNewsGridViewTest extends GreenCityTestRunner {
     public void verifyDefaultImageTest() {
         logger.info("Verify that news article has default image if it was not uploaded");
         User user = UserRepository.get().temporary();
+        NewsData newsData = NewsDataRepository.get().getNewsWithValidData();
         EcoNewsPage ecoNewsPage = loadApplication()
                 .signIn()
                 .getManualLoginComponent()
                 .successfullyLogin(user)
                 .navigateMenuEcoNews()
                 .gotoCreateNewsPage()
-                .fillFields(NewsDataRepository.get().getNewsWithValidData())
+                .fillFields(newsData)
                 .publishNews();
         for (Integer integer : screenWidth) {
             ecoNewsPage.changeWindowWidth(integer);
             softAssert.assertEquals(ecoNewsPage.getImageAttribute(), defaultImagePath);
         }
+        //Clean up
+        EcoNewsService ecoNewsService = new EcoNewsService();
+        ecoNewsService.deleteNewsByTitle(newsData.getTitle());
 
     }
 
@@ -207,7 +213,7 @@ public class EcoNewsGridViewTest extends GreenCityTestRunner {
         }
     }
 
-    @Ignore //runs too long
+    //@Ignore //runs too long
     @Test
     @Description("GC-674")
     public void newsAligningTest() {

--- a/src/test/java/com/softserve/edu/greencity/ui/tests/viewallnews/EcoNewsListViewTests.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/tests/viewallnews/EcoNewsListViewTests.java
@@ -9,10 +9,7 @@ import com.softserve.edu.greencity.ui.tests.runner.GreenCityTestRunner;
 import com.softserve.edu.greencity.ui.tools.jdbc.services.EcoNewsService;
 import io.qameta.allure.Description;
 import org.testng.Assert;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
+import org.testng.annotations.*;
 import org.testng.asserts.SoftAssert;
 
 import java.util.ArrayList;
@@ -154,6 +151,7 @@ public class EcoNewsListViewTests extends GreenCityTestRunner {
         softAssert.assertAll();
     }
 
+    @Ignore //Runs too long
     @Test(testName = "GC-720")
     @Description("Verify that content items contain all required UI elements according to mock-up.")
     public void isPresentAllContentElements() {

--- a/src/test/java/com/softserve/edu/greencity/ui/tests/viewallnews/EcoNewsListViewTests.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/tests/viewallnews/EcoNewsListViewTests.java
@@ -151,7 +151,7 @@ public class EcoNewsListViewTests extends GreenCityTestRunner {
         softAssert.assertAll();
     }
 
-    @Ignore //Runs too long
+    //@Ignore //Runs too long
     @Test(testName = "GC-720")
     @Description("Verify that content items contain all required UI elements according to mock-up.")
     public void isPresentAllContentElements() {

--- a/src/test/java/com/softserve/edu/greencity/ui/tests/viewsinglenews/EcoNewsSingleViewTest.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/tests/viewsinglenews/EcoNewsSingleViewTest.java
@@ -16,6 +16,7 @@ import com.softserve.edu.greencity.ui.tools.TagsUtill;
 import com.softserve.edu.greencity.ui.tools.jdbc.services.EcoNewsService;
 import io.qameta.allure.Description;
 import org.testng.Assert;
+import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -42,6 +43,7 @@ public class EcoNewsSingleViewTest extends GreenCityTestRunner {
         Assert.assertTrue(ecoNewsPage.isActiveListView());
     }
 
+    //@Ignore //Runs too long
     @Test
     @Description("GC-671")
     public void returnToFilteredNews() {
@@ -108,6 +110,9 @@ public class EcoNewsSingleViewTest extends GreenCityTestRunner {
                 .editNewsButtonExist();
 
         Assert.assertTrue(editButtonExist, "Edit button doesn't exist");
+        //Clean up
+        EcoNewsService ecoNewsService = new EcoNewsService();
+        ecoNewsService.deleteNewsByTitle(news.getTitle());
     }
 
     @Test(testName = "GC-692")


### PR DESCRIPTION
It seems that all (or at least most of) cases, where StaleElementReferenceException is thrown, are fixed. Affected tests:

- CreateNews

- GridView

- ListView

- SingleNews