### PR TITLE
Fix EcoNewsCommentTests

### DIFF
--- a/src/main/java/com/softserve/edu/greencity/ui/pages/common/CommentPart.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/pages/common/CommentPart.java
@@ -55,6 +55,7 @@ public class CommentPart implements StableWebElementSearch {
     public CommentPart clickPublishCommentButton() {
         int currentCount = getCommentComponents().size();
         getPublishCommentButton().click();
+        //Mind pagination! Only 10 comments are displayed
             waitsSwitcher.setExplicitWait(10,
                     ExpectedConditions.numberOfElementsToBe(COMMENTS_LIST.getPath(), currentCount + 1));
         return new CommentPart(driver);

--- a/src/main/java/com/softserve/edu/greencity/ui/pages/econews/CreateNewsPage.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/pages/econews/CreateNewsPage.java
@@ -55,8 +55,9 @@ public class CreateNewsPage extends TopPart {
     }
 
     @Step("Set title field")
-    public void setTitleField(String text) {
+    public CreateNewsPage setTitleField(String text) {
         getTitleField().sendKeys(text);
+        return  this;
     }
 
     @Step("Get title field height")
@@ -125,8 +126,9 @@ public class CreateNewsPage extends TopPart {
     }
 
     @Step("Set content field")
-    public void setContentField(String text) {
+    public CreateNewsPage setContentField(String text) {
         getContentField().sendKeys(text);
+        return this;
     }
 
     @Step("Get content field text")

--- a/src/main/java/com/softserve/edu/greencity/ui/pages/econews/EcoNewsPage.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/pages/econews/EcoNewsPage.java
@@ -361,6 +361,7 @@ public class EcoNewsPage extends TopPart {
     @Step("Switch to single news page by parameters")
     public SingleNewsPage switchToSingleNewsPageByParameters(NewsData news) {
         logger.info("Switch to single news page by parameters");
+        itemsContainer = getItemsContainer();
         scrollToElement(itemsContainer.findItemComponentByParameters(news).getTitle());
         itemsContainer.clickItemComponentOpenPage(news);
         return new SingleNewsPage(driver);

--- a/src/main/java/com/softserve/edu/greencity/ui/pages/econews/ItemsContainer.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/pages/econews/ItemsContainer.java
@@ -130,19 +130,16 @@ public class ItemsContainer implements StableWebElementSearch {
      * @return ItemComponent
      */
     protected ItemComponent findItemComponentByParameters(NewsData news) {
-        ItemComponent result = null;
         for (ItemComponent cur : getItemComponents()) {
             if (cur.getTitleText().toLowerCase().equals(news.getTitle().toLowerCase())
                     && cur.getTagsText().equals(news.getTagsName())
-                    && news.getContent().toLowerCase().contains(cur.getContentText().toLowerCase())) {
-                result = cur;
+                    && news.getContent().toLowerCase().trim().equals(cur.getContentText().toLowerCase().trim())
+            ) {
+                return cur;
             }
         }
-        if (result == null) {
-            logger.warn("News with parameters " + news.toString() + "not exist");
-            throw new RuntimeException("ItemComponent with parameters " + news.toString() + " not found");
-        }
-        return result;
+        logger.warn("News with parameters " + news.toString() + " does not exist");
+        throw new RuntimeException("ItemComponent with parameters " + news.toString() + " not found");
     }
 
     /**

--- a/src/test/java/com/softserve/edu/greencity/ui/tests/comments/EcoNewsCommentTests.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/tests/comments/EcoNewsCommentTests.java
@@ -2,30 +2,55 @@ package com.softserve.edu.greencity.ui.tests.comments;
 
 import com.softserve.edu.greencity.ui.data.User;
 import com.softserve.edu.greencity.ui.data.UserRepository;
+import com.softserve.edu.greencity.ui.data.econews.NewsData;
+import com.softserve.edu.greencity.ui.data.econews.Tag;
 import com.softserve.edu.greencity.ui.pages.econews.SingleNewsPage;
 import com.softserve.edu.greencity.ui.tests.runner.GreenCityTestRunner;
+import com.softserve.edu.greencity.ui.tools.jdbc.services.EcoNewsService;
 import io.qameta.allure.Description;
 import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+
 public class EcoNewsCommentTests extends GreenCityTestRunner {
+    private NewsData newsData;
+
     @BeforeClass
     public void creatingCommentToNews() {
         String comment = "different news";
         User user = UserRepository.get().temporary();
 
-        SingleNewsPage page = loadApplication()
+        newsData = new NewsData(Arrays.asList(new Tag[]{Tag.ADS}), "Comment, please!",
+                "I need a lot of comments! Comment, go on!");
+
+        loadApplication()
                 .signIn()
                 .getManualLoginComponent()
                 .successfullyLogin(user)
                 .navigateMenuEcoNews()
-                .switchToSingleNewsPageByNumber(0);
+                .gotoCreateNewsPage()
+                .fillFields(newsData)
+                .clickPublishButton();
+
+        SingleNewsPage page = loadApplication()
+                .navigateMenuEcoNews()
+                .refreshPage() //fresh news might not be displayed unless you refresh
+                .switchToSingleNewsPageByParameters(newsData);
         page.getCommentPart()
                 .addComment(comment);
         page.signOut()
                 .navigateMenuEcoNews()
-                .switchToSingleNewsPageByNumber(0);
+                .switchToSingleNewsPageByParameters(newsData);
+    }
+
+    @AfterClass
+    public void clearUp() {
+        EcoNewsService ecoNewsService = new EcoNewsService();
+        ecoNewsService.deleteNewsByTitle(newsData.getTitle());
     }
 
     @Test(testName = "GC-872")
@@ -53,7 +78,7 @@ public class EcoNewsCommentTests extends GreenCityTestRunner {
                 .chooseReplyByNumber(0).isEditReplyButtonDisplayed());
     }
 
-    @Test(description = "GC-871")
+    @Test(testName = "GC-871")
     @Description("Logged users can edit their own replies on the 'News' page.")
     public void loggedUsersCanEditTheirReply() {
         logger.info("Verify that logged users can edit their own reply on the News page");
@@ -73,7 +98,7 @@ public class EcoNewsCommentTests extends GreenCityTestRunner {
                 .clickReplyEditButton();
     }
 
-    @Test(description = "GC-861")
+    @Test(testName = "GC-861")
     @Description("Logged users can edit their own comments on the 'News' page.")
     public void loggedUsersCanEditOwnComments() {
         User user = UserRepository.get().temporary();
@@ -89,9 +114,9 @@ public class EcoNewsCommentTests extends GreenCityTestRunner {
 
     }
 
-    @Test(description = "GC-862")
+    @Test(testName = "GC-862")
     @Description("Unlogged users can not edit their own comments on the 'News' page.")
     public void unloggedUsersCanNotEditComments() {
-
+        throw new SkipException("This test is not implemented!");
     }
 }


### PR DESCRIPTION
Fixed EcoNewsCommentTests @BeforeClass and method EcoNewsPage.switchToSingleNewsPageByParameters()

The test class crashed when the last news already had 10+ comments (pagination). Now a new news created for this purpose (and deleted later).