### PR TITLE
Parallel run optimisation and fixes

### DIFF
--- a/src/main/java/com/softserve/edu/greencity/ui/api/mail/GoogleMailAPI.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/api/mail/GoogleMailAPI.java
@@ -71,23 +71,27 @@ public class GoogleMailAPI  {
         waitFroMassagesWithSubject("Verify your email address",true,5,10);
         String link = "";
         int count = 0;
-        while (true) {
-            Message[] email = emailUtils.getMessagesBySubject("Verify your email address", true, 5);
-            String mailContent = emailUtils.getMessageContent(email[0]).trim().replaceAll("\\s+", "");
-            Pattern pattern = Pattern.compile("https://greencity[^\"]+");
-            final Matcher m = pattern.matcher(mailContent);
-            m.find();
-            link = mailContent.substring( m.start(), m.end() )
-                    .replace("3D","")
-                    .replace("amp;","")
-                    .replace("=","")
-                    .replace("token","token=")
-                    .replace("user_id","user_id=");
-            if (++count == maxTries) {
-                return null;
-            }
-            return link;
+        Message[] email;
+        do {
+            email = emailUtils.getMessagesBySubject("Verify your email address", true, 5);
+        } while ((email.length == 0) && (++count < maxTries));
+
+        if(email.length == 0) {
+            return null;
         }
+
+        String mailContent = emailUtils.getMessageContent(email[0]).trim().replaceAll("\\s+", "");
+        Pattern pattern = Pattern.compile("https://greencity[^\"]+");
+        final Matcher m = pattern.matcher(mailContent);
+        m.find();
+        link = mailContent.substring( m.start(), m.end() )
+                .replace("3D","")
+                .replace("amp;","")
+                .replace("=","")
+                .replace("token","token=")
+                .replace("user_id","user_id=");
+
+        return link;
     }
 
     @Step("get green city auth confirm link from first mail")

--- a/src/main/java/com/softserve/edu/greencity/ui/api/mail/GoogleMailAPI.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/api/mail/GoogleMailAPI.java
@@ -42,7 +42,7 @@ public class GoogleMailAPI  {
     @SneakyThrows(Exception.class)
     @Step("get array of messages")
     public Message[] getMassagesBySubject(String subject, boolean unread, int maxToSearch, long timeToWait){
-        waitFroMassagesWithSubject(subject,unread,maxToSearch,timeToWait);
+        waitForMassagesWithSubject(subject,unread,maxToSearch,timeToWait);
         return emailUtils.getMessagesBySubject(subject, unread,  maxToSearch);
     }
 
@@ -68,7 +68,7 @@ public class GoogleMailAPI  {
     @SneakyThrows(Exception.class)
     public String getconfirmURL(String mail, String pass,int maxTries) {
         connectToEmail(mail,pass);
-        waitFroMassagesWithSubject("Verify your email address",true,5,10);
+        waitForMassagesWithSubject("Verify your email address",true,5,30);
         String link = "";
         int count = 0;
         Message[] email;
@@ -98,7 +98,7 @@ public class GoogleMailAPI  {
     @SneakyThrows(Exception.class)
     public String getconfirmURL(String subject, String mail, String pass,String regex) {
         connectToEmail(mail,pass);
-        waitFroMassagesWithSubject(subject,true,5,10);
+        waitForMassagesWithSubject(subject,true,5,10);
         String link = "";
             Message[] email = emailUtils.getMessagesBySubject("Verify your email address", true, 5);
             String mailContent = emailUtils.getMessageContent(email[0]).trim().replaceAll("\\s+", "");
@@ -130,7 +130,7 @@ public class GoogleMailAPI  {
 
     @SneakyThrows(Exception.class)
     @Step("get array of messages")
-    public void waitFroMassagesWithSubject(String subject, boolean unread, int maxToSearch, long timeToWaitInSeconds){
+    public void waitForMassagesWithSubject(String subject, boolean unread, int maxToSearch, long timeToWaitInSeconds){
         logger.info("Wait for email with subject: " + subject);
         User user = UserRepository.get().googleUserCredentials();
         connectToEmail(user.getEmail(),user.getPassword());
@@ -149,7 +149,7 @@ public class GoogleMailAPI  {
 
     @SneakyThrows(Exception.class)
     @Step("get array of messages")
-    public void waitFroMassagesWithSubject(String subject, boolean unread, int maxToSearch, long timeToWaitInSeconds,String email, String emailPassword){
+    public void waitForMassagesWithSubject(String subject, boolean unread, int maxToSearch, long timeToWaitInSeconds, String email, String emailPassword){
         logger.info("Wait for email with subject: " + subject);
         long start = System.nanoTime()/ 1000000000;
         long end = start + ((long) timeToWaitInSeconds);

--- a/src/main/java/com/softserve/edu/greencity/ui/pages/cabinet/GoogleAccountManagerPage.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/pages/cabinet/GoogleAccountManagerPage.java
@@ -18,7 +18,7 @@ public class GoogleAccountManagerPage {
     private static String GOOGLE_ACCOUNT_MANAGE_URL = "https://myaccount.google.com/";
     private static String GOOGLE_MAIL_URL = "https://mail.google.com/mail/";
 
-    private By accountButton = By.cssSelector(".gb_Ia.gbii");
+    private By accountButton = By.xpath("//a[@role='button']/img");
     private By signOutButton = By.id("gb_71");
 
     public GoogleAccountManagerPage(WebDriver driver) {

--- a/src/main/java/com/softserve/edu/greencity/ui/pages/cabinet/ManualRegisterComponent.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/pages/cabinet/ManualRegisterComponent.java
@@ -427,7 +427,7 @@ public class ManualRegisterComponent extends RegisterComponent implements Stable
     }
 
     private ManualRegisterComponent waitForConfirmationEmail() {
-        new GoogleMailAPI().waitFroMassagesWithSubject("Verify your email address",true,5,30);
+        new GoogleMailAPI().waitForMassagesWithSubject("Verify your email address",true,5,30);
         return this;
     }
 

--- a/src/main/java/com/softserve/edu/greencity/ui/pages/econews/EcoNewsPage.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/pages/econews/EcoNewsPage.java
@@ -423,9 +423,9 @@ public class EcoNewsPage extends TopPart {
     }
 
     @Step
-    public String getImageAttribute() {
+    public String getImageAttribute(NewsData newsData) {
        return getItemsContainer().
-                       chooseNewsByNumber(0).
+                       findItemComponentByParameters(newsData).
                        getImage().
                        getAttribute("src");
 

--- a/src/main/java/com/softserve/edu/greencity/ui/pages/econews/ItemsContainer.java
+++ b/src/main/java/com/softserve/edu/greencity/ui/pages/econews/ItemsContainer.java
@@ -129,11 +129,11 @@ public class ItemsContainer implements StableWebElementSearch {
      * @param news
      * @return ItemComponent
      */
-    protected ItemComponent findItemComponentByParameters(NewsData news) {
+    public ItemComponent findItemComponentByParameters(NewsData news) {
         for (ItemComponent cur : getItemComponents()) {
             if (cur.getTitleText().toLowerCase().equals(news.getTitle().toLowerCase())
                     && cur.getTagsText().equals(news.getTagsName())
-                    && news.getContent().toLowerCase().trim().equals(cur.getContentText().toLowerCase().trim())
+                    && news.getContent().toLowerCase().trim().contains(cur.getContentText().toLowerCase().trim())
             ) {
                 return cur;
             }

--- a/src/test/java/com/softserve/edu/greencity/ui/tests/runner/GreenCityTestRunner.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/tests/runner/GreenCityTestRunner.java
@@ -80,7 +80,7 @@ public abstract class GreenCityTestRunner {
                     new URL("http://localhost:4444/wd/hub"), options);
         }
         driver.manage().timeouts().implicitlyWait(5, TimeUnit.SECONDS);
-        driver.manage().timeouts().pageLoadTimeout(65, TimeUnit.SECONDS);
+        driver.manage().timeouts().pageLoadTimeout(80, TimeUnit.SECONDS);
         driver.manage().window().maximize();
         /*<============================Local============================>*/
     }

--- a/src/test/java/com/softserve/edu/greencity/ui/tests/signin/ForgotPasswordTests.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/tests/signin/ForgotPasswordTests.java
@@ -140,7 +140,7 @@ public class ForgotPasswordTests extends GreenCityTestRunner {
         softAssert.assertEquals(emailFieldBorderColor, expectedBorderColorRBG); //fails, bug, expected color = red, actual = gray
         softAssert.assertTrue(forgotPasswordComponent.getEmailValidationErrorText().contains(NOT_EXISTING_EMAIL_MESSAGE.getText()));
 
-        googleMailAPI().waitFroMassagesWithSubject(FORGOT_PASS_MAIL_SUBJECT.getText(),
+        googleMailAPI().waitForMassagesWithSubject(FORGOT_PASS_MAIL_SUBJECT.getText(),
                 true, 3, 10, user.getEmail(), user.getPassword());
         int numberOfEmail = new GoogleMailAPI().getNumberMailsBySubject(user.getEmail(), user.getPassword(),
                 FORGOT_PASS_MAIL_SUBJECT.getText(), 50);
@@ -161,7 +161,7 @@ public class ForgotPasswordTests extends GreenCityTestRunner {
                 .clickForgotPasswordLink()
                 .successfullySubmit(user);
 
-        googleMailAPI().waitFroMassagesWithSubject(FORGOT_PASS_MAIL_SUBJECT.getText(),
+        googleMailAPI().waitForMassagesWithSubject(FORGOT_PASS_MAIL_SUBJECT.getText(),
                 true, 3, 30, user.getEmail(), user.getPassword());
         int numberOfEmail = new GoogleMailAPI().getNumberMailsBySubject(user.getEmail(), user.getPassword(),
                 FORGOT_PASS_MAIL_SUBJECT.getText(), 5);
@@ -187,7 +187,7 @@ public class ForgotPasswordTests extends GreenCityTestRunner {
         softAssert.assertTrue(forgotPasswordComponent.getEmailValidationErrorText()
                 .contains(RESTORE_EMAIL_ERROR_MESSAGE.getText()));
 
-        googleMailAPI().waitFroMassagesWithSubject(FORGOT_PASS_MAIL_SUBJECT.getText(),
+        googleMailAPI().waitForMassagesWithSubject(FORGOT_PASS_MAIL_SUBJECT.getText(),
                 true, 3, 10, user.getEmail(), user.getPassword());
         int numberOfEmail = new GoogleMailAPI().getNumberMailsBySubject(user.getEmail(), user.getPassword(),
                 FORGOT_PASS_MAIL_SUBJECT.getText(), 20);

--- a/src/test/java/com/softserve/edu/greencity/ui/tests/signin/GoogleSignInTest.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/tests/signin/GoogleSignInTest.java
@@ -1,0 +1,74 @@
+package com.softserve.edu.greencity.ui.tests.signin;
+
+import com.softserve.edu.greencity.ui.data.User;
+import com.softserve.edu.greencity.ui.data.UserRepository;
+import com.softserve.edu.greencity.ui.pages.common.WelcomePage;
+import com.softserve.edu.greencity.ui.tests.runner.GreenCityTestRunner;
+import io.qameta.allure.Description;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static com.softserve.edu.greencity.ui.tests.signin.SignInTexts.TOP_USER_NAME;
+
+//TODO auth in google via api before clickSingInWithGoogleButton()
+public class GoogleSignInTest extends GreenCityTestRunner {
+
+    @Test(testName = "GC-218", description = "GC-218")
+    @Description("Verify that Unregistered user can Sign Up with Google account")
+    public void signUpByGoogle() {
+        logger.info("Starting signUpByGoogle");
+        User user = UserRepository.get().googleUserCredentials();
+
+        WelcomePage welcomePage = loadApplication();
+        welcomePage
+                .signUp()
+                .clickGoogleSignUpButton()
+                .successfulLoginByGoogle(user);
+        String topUserName = welcomePage.getTopUserName();
+
+        welcomePage.signOut().googleAccountSignOut();
+
+        Assert.assertEquals(topUserName, TOP_USER_NAME.getText());
+    }
+
+    @Test(testName = "GC-220", description = "GC-220")
+    @Description("Verify that Unregistered user can Sign In with Google account")
+    public void signInByGoogle() {
+        logger.info("Starting signInByGoogle");
+        User user = UserRepository.get().googleUserCredentials();
+
+        WelcomePage welcomePage = loadApplication();
+        welcomePage
+                .signIn()
+                .clickSingInWithGoogleButton()
+                .successfulLoginByGoogle(user);
+
+        String topUserName = welcomePage.getTopUserName();
+
+        welcomePage.signOut().googleAccountSignOut();
+
+        Assert.assertEquals(topUserName, TOP_USER_NAME.getText());
+    }
+
+    @Test(testName = "GC-234", description = "GC-234")
+    @Description("Verify that user can't sign in with Google Account credentials on 'Sign in' pop-up window")
+    public void signInByGoogleCredentialsOnManualSignInPopUp() {
+        logger.info("Starting signInByGoogleCredentialsOnManualSignInPopUp");
+        User user = UserRepository.get().googleUserCredentials();
+        WelcomePage welcomePage = loadApplication()
+                .signUp()
+                .clickGoogleSignUpButton()
+                .successfulLoginByGoogle(user);
+        softAssert.assertEquals(welcomePage.getTopUserName(), TOP_USER_NAME.getText());
+
+        welcomePage.signOut().googleAccountSignOut();
+        WebElement wrongEmailOrPasswordError = loadApplication()
+                .signIn()
+                .getManualLoginComponent()
+                .unsuccessfullyLogin(user)
+                .getWrongEmailOrPassError();
+        softAssert.assertTrue(wrongEmailOrPasswordError.isDisplayed());
+        softAssert.assertAll();
+    }
+}

--- a/src/test/java/com/softserve/edu/greencity/ui/tests/signin/LoginTest.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/tests/signin/LoginTest.java
@@ -1,20 +1,17 @@
 package com.softserve.edu.greencity.ui.tests.signin;
 
-import com.softserve.edu.greencity.ui.tests.runner.GreenCityTestRunner;
-import io.qameta.allure.Description;
-import org.openqa.selenium.WebElement;
-import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-
 import com.softserve.edu.greencity.ui.data.User;
 import com.softserve.edu.greencity.ui.data.UserRepository;
 import com.softserve.edu.greencity.ui.pages.cabinet.LoginComponent;
 import com.softserve.edu.greencity.ui.pages.cabinet.ManualLoginComponent;
 import com.softserve.edu.greencity.ui.pages.cabinet.MyCabinetPage;
 import com.softserve.edu.greencity.ui.pages.common.TopGuestComponent;
-import com.softserve.edu.greencity.ui.pages.common.WelcomePage;
+import com.softserve.edu.greencity.ui.tests.runner.GreenCityTestRunner;
+import io.qameta.allure.Description;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 import static com.softserve.edu.greencity.ui.tests.signin.SignInTexts.*;
 
@@ -303,9 +300,9 @@ public class LoginTest extends GreenCityTestRunner {
         manualLoginComponent.getEmailField().clear();
         String emailFieldBorderColor = manualLoginComponent.getEmailField().getCssValue(cssBorderColorProperty);
 
-    softAssert.assertEquals(emailFieldBorderColor, expectedBorderColorRBG);
-    softAssert.assertTrue(manualLoginComponent.isUnsuccessfulEmailValidation());
-    softAssert.assertAll();
+        softAssert.assertEquals(emailFieldBorderColor, expectedBorderColorRBG);
+        softAssert.assertTrue(manualLoginComponent.isUnsuccessfulEmailValidation());
+        softAssert.assertAll();
     }
 
     @Test(testName = "GC-526", description = "GC-526")
@@ -358,64 +355,5 @@ public class LoginTest extends GreenCityTestRunner {
                 .signIn().getTitleText();
 
         Assert.assertEquals(titleString, SIGN_IN_TITLE.getText());
-    }
-    //TODO auth in google via api before clickSingInWithGoogleButton()
-    @Test(testName = "GC-218", description = "GC-218")
-    @Description("Verify that Unregistered user can Sign Up with Google account")
-    public void signUpByGoogle() {
-        logger.info("Starting signUpByGoogle");
-        User user = UserRepository.get().googleUserCredentials();
-
-        WelcomePage welcomePage = loadApplication();
-        welcomePage
-                .signUp()
-                .clickGoogleSignUpButton()
-                .successfulLoginByGoogle(user);
-        String topUserName = welcomePage.getTopUserName();
-
-        welcomePage.signOut().googleAccountSignOut();
-
-        Assert.assertEquals(topUserName, TOP_USER_NAME.getText());
-    }
-//TODO auth in google via api before clickSingInWithGoogleButton()
-    @Test(testName = "GC-220", description = "GC-220")
-    @Description("Verify that Unregistered user can Sign In with Google account")
-    public void signInByGoogle() {
-        logger.info("Starting signInByGoogle");
-        User user = UserRepository.get().googleUserCredentials();
-
-        WelcomePage welcomePage = loadApplication();
-        welcomePage
-                .signIn()
-                .clickSingInWithGoogleButton()
-                .successfulLoginByGoogle(user);
-
-        String topUserName = welcomePage.getTopUserName();
-
-        welcomePage.signOut().googleAccountSignOut();
-
-        Assert.assertEquals(topUserName, TOP_USER_NAME.getText());
-    }
-
-    //TODO auth in google via api before clickSingInWithGoogleButton()
-    @Test(testName = "GC-234", description = "GC-234")
-    @Description("Verify that user can't sign in with Google Account credentials on 'Sign in' pop-up window")
-    public void signInByGoogleCredentialsOnManualSignInPopUp() {
-        logger.info("Starting signInByGoogleCredentialsOnManualSignInPopUp");
-        User user = UserRepository.get().googleUserCredentials();
-        WelcomePage welcomePage = loadApplication()
-                .signUp()
-                .clickGoogleSignUpButton()
-                .successfulLoginByGoogle(user);
-        softAssert.assertEquals(welcomePage.getTopUserName(), TOP_USER_NAME.getText());
-
-        welcomePage.signOut().googleAccountSignOut();
-        WebElement wrongEmailOrPasswordError = loadApplication()
-                .signIn()
-                .getManualLoginComponent()
-                .unsuccessfullyLogin(user)
-                .getWrongEmailOrPassError();
-        softAssert.assertTrue(wrongEmailOrPasswordError.isDisplayed());
-        softAssert.assertAll();
     }
 }

--- a/src/test/java/com/softserve/edu/greencity/ui/tests/signup/RegistrationTests.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/tests/signup/RegistrationTests.java
@@ -86,9 +86,9 @@ public class RegistrationTests extends GreenCityTestRunner {
 
         softAssert.assertTrue(registerComponent.getCongratsModal().isDisplayed());
 
-        waitsSwitcher.setExplicitWait(7, ExpectedConditions.visibilityOfAllElementsLocatedBy(By.cssSelector((LoginComponent.MODAL_WINDOW_CSS))));
-
-        ManualLoginComponent manualLoginComponent = new ManualLoginComponent(driver);
+        //TMind that now the login window doesn't appear automatically
+        waitsSwitcher.setExplicitWait(10, ExpectedConditions.invisibilityOf(registerComponent.getCongratsModal()));
+        ManualLoginComponent manualLoginComponent = (new TopGuestComponent(driver)).clickSignInLink().getManualLoginComponent();
 
         manualLoginComponent.unsuccessfullyLogin(userLoginCredentials);
 
@@ -138,7 +138,7 @@ public class RegistrationTests extends GreenCityTestRunner {
         softAssert.assertEquals(
                 manualRegisterComponent
                         .getSignUpErrorsMsg(1),
-                "User with this email is already registered",
+                "The user already exists by this email",
                 "error msg mismatch"
         );
         softAssert.assertAll();

--- a/src/test/java/com/softserve/edu/greencity/ui/tests/signup/RegistrationTests.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/tests/signup/RegistrationTests.java
@@ -1,25 +1,25 @@
 package com.softserve.edu.greencity.ui.tests.signup;
 
+import com.softserve.edu.greencity.ui.api.mail.GoogleMailAPI;
 import com.softserve.edu.greencity.ui.data.User;
 import com.softserve.edu.greencity.ui.data.UserRepository;
-import com.softserve.edu.greencity.ui.pages.cabinet.*;
+import com.softserve.edu.greencity.ui.pages.cabinet.LoginComponent;
+import com.softserve.edu.greencity.ui.pages.cabinet.ManualLoginComponent;
+import com.softserve.edu.greencity.ui.pages.cabinet.ManualRegisterComponent;
+import com.softserve.edu.greencity.ui.pages.cabinet.RegisterComponent;
 import com.softserve.edu.greencity.ui.pages.common.TopGuestComponent;
 import com.softserve.edu.greencity.ui.tests.runner.GreenCityTestRunner;
-import com.softserve.edu.greencity.ui.api.mail.GoogleMailAPI;
+import com.softserve.edu.greencity.ui.tools.engine.WaitsSwitcher;
 import io.qameta.allure.Description;
 import lombok.SneakyThrows;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.concurrent.TimeUnit;
-
 //TODO add DB check
 public class RegistrationTests extends GreenCityTestRunner {
-
     private final String SIGN_IN_TITLE = "Welcome back!";
 
     @DataProvider
@@ -81,14 +81,12 @@ public class RegistrationTests extends GreenCityTestRunner {
 
         logger.info("Enter credentials into the form");
         manualRegisterComponent.registrationUser(userLoginCredentials);
-        driver.manage().timeouts().implicitlyWait(0, TimeUnit.SECONDS);
-        WebDriverWait wait = new WebDriverWait(driver, 6);
+        WaitsSwitcher waitsSwitcher = new WaitsSwitcher(driver);
+        waitsSwitcher.setExplicitWait(7, ExpectedConditions.visibilityOf(registerComponent.getCongratsModal()));
 
-        wait.until(ExpectedConditions.visibilityOf(registerComponent.getCongratsModal()));
-        driver.manage().timeouts().implicitlyWait(5, TimeUnit.SECONDS);
         softAssert.assertTrue(registerComponent.getCongratsModal().isDisplayed());
 
-        wait.until(ExpectedConditions.visibilityOfAllElementsLocatedBy(By.cssSelector((LoginComponent.MODAL_WINDOW_CSS))));
+        waitsSwitcher.setExplicitWait(7, ExpectedConditions.visibilityOfAllElementsLocatedBy(By.cssSelector((LoginComponent.MODAL_WINDOW_CSS))));
 
         ManualLoginComponent manualLoginComponent = new ManualLoginComponent(driver);
 

--- a/src/test/java/com/softserve/edu/greencity/ui/tests/viewallnews/EcoNewsGridViewTest.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/tests/viewallnews/EcoNewsGridViewTest.java
@@ -187,7 +187,7 @@ public class EcoNewsGridViewTest extends GreenCityTestRunner {
                 .publishNews();
         for (Integer integer : screenWidth) {
             ecoNewsPage.changeWindowWidth(integer);
-            softAssert.assertEquals(ecoNewsPage.getImageAttribute(), defaultImagePath);
+            softAssert.assertEquals(ecoNewsPage.getImageAttribute(newsData), defaultImagePath);
         }
         //Clean up
         EcoNewsService ecoNewsService = new EcoNewsService();

--- a/src/test/java/com/softserve/edu/greencity/ui/tests/viewallnews/EcoNewsListViewTests.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/tests/viewallnews/EcoNewsListViewTests.java
@@ -2,6 +2,7 @@ package com.softserve.edu.greencity.ui.tests.viewallnews;
 
 import com.softserve.edu.greencity.ui.data.User;
 import com.softserve.edu.greencity.ui.data.UserRepository;
+import com.softserve.edu.greencity.ui.data.econews.NewsData;
 import com.softserve.edu.greencity.ui.data.econews.NewsDataRepository;
 import com.softserve.edu.greencity.ui.pages.econews.EcoNewsPage;
 import com.softserve.edu.greencity.ui.pages.econews.ItemComponent;
@@ -155,36 +156,37 @@ public class EcoNewsListViewTests extends GreenCityTestRunner {
     public void isPresentAllContentElements() {
         logger.info("isPresentAllContentElements");
         User user = UserRepository.get().temporary();
+        NewsData newsData = NewsDataRepository.get().getOneRowTitle();
         EcoNewsPage ecoNewsPage = loadApplication()
                 .signIn()
                 .getManualLoginComponent()
                 .successfullyLogin(user)
                 .navigateMenuEcoNews()
                 .gotoCreateNewsPage()
-                .fillFields(NewsDataRepository.get().getOneRowTitle())
+                .fillFields(newsData)
                 .publishNews();
 
-        testNewsTitles.add(NewsDataRepository.get().getOneRowTitle().getTitle());
+        testNewsTitles.add(newsData.getTitle());
 
         for (Integer integer : screenWidthWithContent) {
             ecoNewsPage.changeWindowWidth(integer);
             logger.info("set width = "+integer);
             logger.info("script width = "+ecoNewsPage.getWindowWidth(integer));
             ecoNewsPage.switchToListView();
-            softAssert.assertTrue(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedImage());
-            logger.info("image " + ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedImage());
-            softAssert.assertTrue(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedTags());
-            logger.info("tags " + ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedTags());
-            softAssert.assertTrue(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedTitle());
-            logger.info("title " + ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedTitle());
-            softAssert.assertTrue(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedContent());
-            logger.info("content " + ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedContent());
-            softAssert.assertTrue(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedDateOfCreation());
-            logger.info("date " + ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedDateOfCreation());
-            softAssert.assertTrue(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isCorrectDateFormat(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).getDateOfCreationText()));
-            logger.info("dateformat " + ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isCorrectDateFormat(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).getDateOfCreationText()));
-            softAssert.assertTrue(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedAuthor());
-            logger.info("author " + ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedAuthor());
+            softAssert.assertTrue(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedImage());
+            logger.info("image " + ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedImage());
+            softAssert.assertTrue(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedTags());
+            logger.info("tags " + ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedTags());
+            softAssert.assertTrue(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedTitle());
+            logger.info("title " + ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedTitle());
+            softAssert.assertTrue(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedContent());
+            logger.info("content " + ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedContent());
+            softAssert.assertTrue(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedDateOfCreation());
+            logger.info("date " + ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedDateOfCreation());
+            softAssert.assertTrue(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isCorrectDateFormat(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).getDateOfCreationText()));
+            logger.info("dateformat " + ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isCorrectDateFormat(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).getDateOfCreationText()));
+            softAssert.assertTrue(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedAuthor());
+            logger.info("author " + ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedAuthor());
 
         }
 
@@ -193,20 +195,20 @@ public class EcoNewsListViewTests extends GreenCityTestRunner {
             logger.info("set width = "+integer);
             logger.info("script width = "+ecoNewsPage.getWindowWidth(integer));
             ecoNewsPage.switchToListView();
-            softAssert.assertTrue(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedImage());
-            logger.info("image " +ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedImage());
-            softAssert.assertTrue(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedTags());
-            logger.info("tags " +ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedTags());
-            softAssert.assertTrue(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedTitle());
-            logger.info("title " +ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedTitle());
-            softAssert.assertFalse(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedContent());
-            logger.info("content " +ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedContent());
-            softAssert.assertTrue(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedDateOfCreation());
-            logger.info("date " +ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedDateOfCreation());
-            softAssert.assertTrue(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isCorrectDateFormat(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).getDateOfCreationText()));
-            logger.info("dateformat " +ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isCorrectDateFormat(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).getDateOfCreationText()));
-            softAssert.assertTrue(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedAuthor());
-            logger.info("author " +ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedAuthor());
+            softAssert.assertTrue(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedImage());
+            logger.info("image " +ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedImage());
+            softAssert.assertTrue(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedTags());
+            logger.info("tags " +ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedTags());
+            softAssert.assertTrue(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedTitle());
+            logger.info("title " +ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedTitle());
+            softAssert.assertFalse(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedContent());
+            logger.info("content " +ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedContent());
+            softAssert.assertTrue(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedDateOfCreation());
+            logger.info("date " +ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedDateOfCreation());
+            softAssert.assertTrue(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isCorrectDateFormat(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).getDateOfCreationText()));
+            logger.info("dateformat " +ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isCorrectDateFormat(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).getDateOfCreationText()));
+            softAssert.assertTrue(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedAuthor());
+            logger.info("author " +ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedAuthor());
 
         }
         for (Integer integer : screenWidthWithoutImages) {
@@ -215,22 +217,22 @@ public class EcoNewsListViewTests extends GreenCityTestRunner {
             logger.info("script width = "+ecoNewsPage.getWindowWidth(integer));
             ecoNewsPage.switchToListView();
             if(ecoNewsPage.isActiveListView()){
-            softAssert.assertFalse(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedImage(), "image");
-            logger.info("image " +ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedImage());
-            softAssert.assertTrue(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedTags(), "tags");
-            logger.info("tags " +ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedTags());
-            softAssert.assertTrue(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedTitle(), "title");
-            logger.info("title " +ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedTitle());
-            softAssert.assertFalse(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedContent(), "content");
-            logger.info("content " +ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedContent());
-            softAssert.assertTrue(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedDateOfCreation(), "date");
-            logger.info("date " +ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedDateOfCreation());
-            softAssert.assertTrue(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0)
-                    .isCorrectDateFormat(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).getDateOfCreationText()),
+            softAssert.assertFalse(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedImage(), "image");
+            logger.info("image " +ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedImage());
+            softAssert.assertTrue(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedTags(), "tags");
+            logger.info("tags " +ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedTags());
+            softAssert.assertTrue(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedTitle(), "title");
+            logger.info("title " +ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedTitle());
+            softAssert.assertFalse(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedContent(), "content");
+            logger.info("content " +ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedContent());
+            softAssert.assertTrue(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedDateOfCreation(), "date");
+            logger.info("date " +ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedDateOfCreation());
+            softAssert.assertTrue(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData)
+                    .isCorrectDateFormat(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).getDateOfCreationText()),
                     "date format");
-            logger.info("dateformat " +ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isCorrectDateFormat(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).getDateOfCreationText()));
-            softAssert.assertTrue(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedAuthor(), "author");
-            logger.info("author " +ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).isDisplayedAuthor());
+            logger.info("dateformat " +ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isCorrectDateFormat(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).getDateOfCreationText()));
+            softAssert.assertTrue(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedAuthor(), "author");
+            logger.info("author " +ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).isDisplayedAuthor());
             }
         }
         ecoNewsPage.maximizeWindow();
@@ -244,6 +246,7 @@ public class EcoNewsListViewTests extends GreenCityTestRunner {
     public void isPresentDefaultImage() {
         logger.info("isPresentDefaultImage");
         User user = UserRepository.get().temporary();
+        NewsData newsData = NewsDataRepository.get().getNewsWithValidData("Default image test");
 
         EcoNewsPage ecoNewsPage = loadApplication()
                 .signIn()
@@ -251,16 +254,16 @@ public class EcoNewsListViewTests extends GreenCityTestRunner {
                 .successfullyLogin(user)
                 .navigateMenuEcoNews()
                 .gotoCreateNewsPage()
-                .fillFields(NewsDataRepository.get().getOneRowTitle())
+                .fillFields(newsData)
                 .publishNews();
 
-        testNewsTitles.add(NewsDataRepository.get().getOneRowTitle().getTitle());
+        testNewsTitles.add(newsData.getTitle());
 
         for (Integer integer : screenWidth1) {
             logger.debug("Screen width: " + integer);
             ecoNewsPage.changeWindowWidth(integer);
             ecoNewsPage.switchToListView();
-            String src = ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).getImage().getAttribute("src");
+            String src = ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).getImage().getAttribute("src");
             softAssert.assertEquals(src, DEFAULT_IMAGE);
         }
         for (Integer integer : screenWidth2) {
@@ -268,7 +271,7 @@ public class EcoNewsListViewTests extends GreenCityTestRunner {
             ecoNewsPage.changeWindowWidth(integer);
             //On small screen resolution list view automatically switches off
             softAssert.assertFalse(ecoNewsPage.isListViewPresent(), "List view at " + integer + " width");
-            String src = ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).getImage().getAttribute("src");
+            String src = ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).getImage().getAttribute("src");
             softAssert.assertEquals(src, DEFAULT_IMAGE);
         }
 
@@ -283,6 +286,7 @@ public class EcoNewsListViewTests extends GreenCityTestRunner {
     public void isZeroRowDescriptionWhenFourRowsTitle() {
         logger.info("isZeroRowDescriptionWhenFourRowsTitle");
         User user = UserRepository.get().temporary();
+        NewsData newsData = NewsDataRepository.get().getFourRowsTitle();
 
         EcoNewsPage ecoNewsPage = loadApplication()
                 .signIn()
@@ -290,19 +294,19 @@ public class EcoNewsListViewTests extends GreenCityTestRunner {
                 .successfullyLogin(user)
                 .navigateMenuEcoNews()
                 .gotoCreateNewsPage()
-                .fillFields(NewsDataRepository.get().getFourRowsTitle())
+                .fillFields(newsData)
                 .publishNews();
 
-        testNewsTitles.add(NewsDataRepository.get().getFourRowsTitle().getTitle());
+        testNewsTitles.add(newsData.getTitle());
 
         ecoNewsPage.changeWindowWidth(1400);
 
         ecoNewsPage.switchToListView();
 
-        Assert.assertEquals(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).getTitleHeight(), 128);
-        Assert.assertEquals(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).getTitleNumberRow(), 4);
-        Assert.assertFalse(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).getContent().isDisplayed());
-        Assert.assertEquals(ecoNewsPage.getItemsContainer().chooseNewsByNumber(0).getContentNumberVisibleRow(), 0);
+        Assert.assertEquals(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).getTitleHeight(), 128);
+        Assert.assertEquals(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).getTitleNumberRow(), 4);
+        Assert.assertFalse(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).getContent().isDisplayed());
+        Assert.assertEquals(ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData).getContentNumberVisibleRow(), 0);
 
         ecoNewsPage.signOut();
         softAssert.assertAll();
@@ -314,6 +318,7 @@ public class EcoNewsListViewTests extends GreenCityTestRunner {
     public void isOneRowDescriptionWhenThreeRowsTitle() {
         logger.info("isOneRowDescriptionWhenThreeRowsTitle");
         User user = UserRepository.get().temporary();
+        NewsData newsData = NewsDataRepository.get().getThreeRowsTitle();
 
         EcoNewsPage ecoNewsPage = loadApplication()
                 .signIn()
@@ -321,16 +326,16 @@ public class EcoNewsListViewTests extends GreenCityTestRunner {
                 .successfullyLogin(user)
                 .navigateMenuEcoNews()
                 .gotoCreateNewsPage()
-                .fillFields(NewsDataRepository.get().getThreeRowsTitle())
+                .fillFields(newsData)
                 .publishNews();
 
-        testNewsTitles.add(NewsDataRepository.get().getThreeRowsTitle().getTitle());
+        testNewsTitles.add(newsData.getTitle());
 
         ecoNewsPage.changeWindowWidth(1400);
 
         ecoNewsPage.switchToListView();
 
-        ItemComponent firstItemTitle = ecoNewsPage.getItemsContainer().chooseNewsByNumber(0);
+        ItemComponent firstItemTitle = ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData);
         softAssert.assertEquals(firstItemTitle.getTitleHeight(), 96);
         softAssert.assertEquals(firstItemTitle.getTitleNumberRow(), 3);
         softAssert.assertEquals(firstItemTitle.getContentNumberVisibleRow(), 1);
@@ -345,6 +350,7 @@ public class EcoNewsListViewTests extends GreenCityTestRunner {
     public void isTwoRowsDescriptionWhenTwoRowsTitle() {
         logger.info("isTwoRowsDescriptionWhenTwoRowsTitle");
         User user = UserRepository.get().temporary();
+        NewsData newsData = NewsDataRepository.get().getTwoRowsTitle();
 
         EcoNewsPage ecoNewsPage = loadApplication()
                 .signIn()
@@ -352,16 +358,16 @@ public class EcoNewsListViewTests extends GreenCityTestRunner {
                 .successfullyLogin(user)
                 .navigateMenuEcoNews()
                 .gotoCreateNewsPage()
-                .fillFields(NewsDataRepository.get().getTwoRowsTitle())
+                .fillFields(newsData)
                 .publishNews();
 
-        testNewsTitles.add(NewsDataRepository.get().getTwoRowsTitle().getTitle());
+        testNewsTitles.add(newsData.getTitle());
 
         ecoNewsPage.changeWindowWidth(1400);
 
         ecoNewsPage.switchToListView();
 
-        ItemComponent firstItemTitle = ecoNewsPage.getItemsContainer().chooseNewsByNumber(0);
+        ItemComponent firstItemTitle = ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData);
         softAssert.assertEquals(firstItemTitle.getTitleHeight(), 64);
         softAssert.assertEquals(firstItemTitle.getTitleNumberRow(), 2);
         softAssert.assertEquals(firstItemTitle.getContentNumberVisibleRow(), 2);
@@ -376,6 +382,7 @@ public class EcoNewsListViewTests extends GreenCityTestRunner {
     public void isTwoRowsDescriptionWhenOneRowsTitle() {
         logger.info("isTwoRowsDescriptionWhenOneRowsTitle");
         User user = UserRepository.get().temporary();
+        NewsData newsData = NewsDataRepository.get().getOneRowTitle();
 
         EcoNewsPage ecoNewsPage = loadApplication()
                 .signIn()
@@ -383,16 +390,16 @@ public class EcoNewsListViewTests extends GreenCityTestRunner {
                 .successfullyLogin(user)
                 .navigateMenuEcoNews()
                 .gotoCreateNewsPage()
-                .fillFields(NewsDataRepository.get().getOneRowTitle())
+                .fillFields(newsData)
                 .publishNews();
 
-        testNewsTitles.add(NewsDataRepository.get().getOneRowTitle().getTitle());
+        testNewsTitles.add(newsData.getTitle());
 
         ecoNewsPage.changeWindowWidth(1440);
 
         ecoNewsPage.switchToListView();
 
-        ItemComponent firstItemTitle = ecoNewsPage.getItemsContainer().chooseNewsByNumber(0);
+        ItemComponent firstItemTitle = ecoNewsPage.getItemsContainer().findItemComponentByParameters(newsData);
         softAssert.assertEquals(firstItemTitle.getTitleHeight(), 32);
         softAssert.assertEquals(firstItemTitle.getTitleNumberRow(), 1);
         softAssert.assertEquals(firstItemTitle.getContentNumberVisibleRow(), 3);

--- a/src/test/java/com/softserve/edu/greencity/ui/tests/viewsinglenews/EcoNewsSingleViewTest.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/tests/viewsinglenews/EcoNewsSingleViewTest.java
@@ -96,7 +96,7 @@ public class EcoNewsSingleViewTest extends GreenCityTestRunner {
     public void verifyEditAvailable() {
         logger.info("verifyEditAvailable starts");
         User user = UserRepository.get().temporary();
-        NewsData news = NewsDataRepository.get().getNewsWithValidData("verifyEditAvailable");
+        NewsData news = NewsDataRepository.get().getNewsWithValidData("VerifyEditAvailable");
         boolean editButtonExist = loadApplication()
                 .signIn()
                 .getManualLoginComponent()

--- a/src/test/java/com/softserve/edu/greencity/ui/tests/viewsinglenews/EcoNewsSingleViewTest.java
+++ b/src/test/java/com/softserve/edu/greencity/ui/tests/viewsinglenews/EcoNewsSingleViewTest.java
@@ -96,7 +96,7 @@ public class EcoNewsSingleViewTest extends GreenCityTestRunner {
     public void verifyEditAvailable() {
         logger.info("verifyEditAvailable starts");
         User user = UserRepository.get().temporary();
-        NewsData news = NewsDataRepository.get().getNewsWithValidData();
+        NewsData news = NewsDataRepository.get().getNewsWithValidData("verifyEditAvailable");
         boolean editButtonExist = loadApplication()
                 .signIn()
                 .getManualLoginComponent()
@@ -105,7 +105,7 @@ public class EcoNewsSingleViewTest extends GreenCityTestRunner {
                 .gotoCreateNewsPage()
                 .fillFields(news)
                 .publishNews()
-                .switchToSingleNewsPageByNumber(0)
+                .switchToSingleNewsPageByParameters(news)
                 .editNewsButtonExist();
 
         Assert.assertTrue(editButtonExist, "Edit button doesn't exist");
@@ -146,7 +146,7 @@ public class EcoNewsSingleViewTest extends GreenCityTestRunner {
                     .gotoCreateNewsPage()
                     .fillFields(newsWithSource)
                     .publishNews()
-                    .switchToSingleNewsPageByNumber(0);
+                    .switchToSingleNewsPageByParameters(newsWithSource);
 
             softAssert.assertTrue(singleNewsPage.getSourceTitleText().length() > 1,
                     "Checking if source title is present");
@@ -158,6 +158,32 @@ public class EcoNewsSingleViewTest extends GreenCityTestRunner {
         } finally {
             EcoNewsService ecoNewsService = new EcoNewsService();
             ecoNewsService.deleteNewsByTitle(newsWithSource.getTitle());
+        }
+    }
+
+    @Test(testName = "GC-731", description = "GC-731")
+    @Description("Source field doesn't appear if User hasn't specified Source in the Create news form.")
+    public void noSourceIfItWasntSpecified() {
+        logger.info("noSourceIfItWasntSpecified starts");
+
+        NewsData newsWithEmptySource = NewsDataRepository.get().getNewsWithoutSource();
+        try {
+            SingleNewsPage singleNewsPage = loadApplication()
+                    .loginIn(UserRepository.get().temporary())
+                    .navigateMenuEcoNews()
+                    .gotoCreateNewsPage()
+                    .fillFields(newsWithEmptySource)
+                    .publishNews()
+                    .switchToSingleNewsPageByParameters(newsWithEmptySource);
+
+            softAssert.assertEquals(singleNewsPage.getSourceLinkText(), "",
+                    "Checking if news has no source");
+            softAssert.assertAll();
+
+            singleNewsPage.signOut();
+        } finally {
+            EcoNewsService ecoNewsService = new EcoNewsService();
+            ecoNewsService.deleteNewsByTitle(newsWithEmptySource.getTitle());
         }
     }
 
@@ -177,33 +203,8 @@ public class EcoNewsSingleViewTest extends GreenCityTestRunner {
             Assert.assertEquals(suggestedNews.getItemComponentsCount(), 3);
             EcoNewsSuggestionsAssertion.assertSuggestionsByDate(suggestedNews, false);
         } else {
-            Assert.assertTrue(false, "Couldn't find suitable tag");
+            Assert.fail("Couldn't find suitable tag");
         }
     }
 
-    @Test(testName = "GC-731", description = "GC-731")
-    @Description("Source field doesn't appear if User hasn't specified Source in the Create news form.")
-    public void noSourceIfItWasntSpecified() {
-        logger.info("noSourceIfItWasntSpecified starts");
-
-        NewsData newsWithEmptySource = NewsDataRepository.get().getNewsWithoutSource();
-        try {
-            SingleNewsPage singleNewsPage = loadApplication()
-                    .loginIn(UserRepository.get().temporary())
-                    .navigateMenuEcoNews()
-                    .gotoCreateNewsPage()
-                    .fillFields(newsWithEmptySource)
-                    .publishNews()
-                    .switchToSingleNewsPageByNumber(0);
-
-            softAssert.assertEquals(singleNewsPage.getSourceLinkText(), "",
-                    "Checking if news has no source");
-            softAssert.assertAll();
-
-            singleNewsPage.signOut();
-        } finally {
-            EcoNewsService ecoNewsService = new EcoNewsService();
-            ecoNewsService.deleteNewsByTitle(newsWithEmptySource.getTitle());
-        }
-    }
 }

--- a/testng.xml
+++ b/testng.xml
@@ -16,7 +16,7 @@
         </classes>
     </test>
 
-    <test name="Registration_and_login">
+    <test name="Registration_and_login" thread-count="5">
         <classes>
             <class name="com.softserve.edu.greencity.ui.tests.signup.RegisterPageTests"/>
             <class name="com.softserve.edu.greencity.ui.tests.signup.RegistrationTests"/>

--- a/testng.xml
+++ b/testng.xml
@@ -1,55 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="Suite" parallel="classes" thread-count="5">
-<!-- ===============================   UI  ============================= -->
-    <test name="UI_smoke">
+
+    <test name="Quick_tests" thread-count="6">
+    <!-- API and other tests that run quickly (1 minute and less) -->
         <classes>
             <class name="com.softserve.edu.greencity.ui.tests.SmokeTest"/>
 
+            <class name="com.softserve.edu.greencity.api.tests.econews.positive.CreateNewsWithMinimalValuesTest"/>
+            <class name="com.softserve.edu.greencity.api.tests.econews.negative.CreateNewsWithArrayResponseTest"/>
+            <class name="com.softserve.edu.greencity.api.tests.econews.negative.CreateNewsWithDetailedResponseTest"/>
+            <class name="com.softserve.edu.greencity.api.tests.econews.negative.CreateNewsWithShortResponseTest"/>
+
+            <class name="com.softserve.edu.greencity.api.tests.signin.SignInApiTest"/>
         </classes>
     </test>
 
-    <test name="UI_registrationAndLogin">
+    <test name="Registration_and_login">
         <classes>
             <class name="com.softserve.edu.greencity.ui.tests.signup.RegisterPageTests"/>
             <class name="com.softserve.edu.greencity.ui.tests.signup.RegistrationTests"/>
             <class name="com.softserve.edu.greencity.ui.tests.signin.ForgotPasswordTests"/>
             <class name="com.softserve.edu.greencity.ui.tests.signin.LoginTest"/>
-<!--
-            <class name="com.softserve.edu.greencity.ui.tests.viewallnews.EcoNewsListViewTests">
-                <methods>
-                    <include name="isItemsDisplayedChronological" />
-                </methods>
-            </class>
--->
+
+            <class name="com.softserve.edu.greencity.ui.tests.viewsinglenews.EcoNewsSingleViewTest"/>
+            <!-- EcoNewsSingleViewTest needs no another news to be created, but creates by itself.
+            So it could be merged only with this suite -->
         </classes>
     </test>
 
-    <test name="UI_createNews">
+    <test name="Google_login" thread-count="1">
+    <!-- Should be run separately, since it interacts with other windows (Google login window) -->
+        <classes>
+            <class name="com.softserve.edu.greencity.ui.tests.signin.GoogleSignInTest"/>
+        </classes>
+    </test>
+
+    <test name="Create_news_independent" thread-count="4">
+    <!-- Tests that create news, but will not fail if other news is created at the same time
+    (these tests should use switchToSingleNewsPageByParameters, but not ByNumber) -->
         <classes>
             <class name="com.softserve.edu.greencity.ui.tests.createnews.CreateNewsPositiveTest"/>
             <class name="com.softserve.edu.greencity.ui.tests.createnews.CreateNewsNegativeTest"/>
             <class name="com.softserve.edu.greencity.ui.tests.createnews.CreateNewsPreviewTest"/>
             <class name="com.softserve.edu.greencity.ui.tests.createnews.CreateNewsLegacyTest"/>
-        </classes>
-    </test>
 
-    <test name="UI_viewAllNews">
-        <classes>
-            <class name="com.softserve.edu.greencity.ui.tests.viewallnews.EcoNewsGridViewTest"/>
-            <class name="com.softserve.edu.greencity.ui.tests.viewallnews.EcoNewsListViewTests"/>
-<!--            <class name="com.softserve.edu.greencity.ui.tests.viewallnews.EcoNewsPageTest"/>-->
-        </classes>
-    </test>
-
-    <test name="UI_viewSingleNews">
-        <classes>
-            <class name="com.softserve.edu.greencity.ui.tests.viewsinglenews.EcoNewsSingleViewTest"/>
-        </classes>
-    </test>
-
-    <test name="UI_comments">
-        <classes>
             <class name="com.softserve.edu.greencity.ui.tests.comments.CheckElementOfCommentTest"/>
             <class name="com.softserve.edu.greencity.ui.tests.comments.CommentCreation"/>
             <class name="com.softserve.edu.greencity.ui.tests.comments.Commentstest"/>
@@ -57,20 +52,22 @@
         </classes>
     </test>
 
-<!-- ===============================   API  ============================= -->
-    <test name="API_registrationAndLogin">
+    <test name="View_all_news">
+<!--        Should be run separately from the tests that create or delete news. Don't create news by themselves-->
         <classes>
-            <class name="com.softserve.edu.greencity.api.tests.signin.SignInApiTest"/>
+            <class name="com.softserve.edu.greencity.ui.tests.viewallnews.EcoNewsGridViewTest"/>
+            <class name="com.softserve.edu.greencity.ui.tests.viewallnews.EcoNewsListViewTests"/>
+<!--            <class name="com.softserve.edu.greencity.ui.tests.viewallnews.EcoNewsPageTest"/>-->
         </classes>
     </test>
 
-    <test name="API_createNews">
-        <classes>
-            <class name="com.softserve.edu.greencity.api.tests.econews.positive.CreateNewsWithMinimalValuesTest"/>
-            <class name="com.softserve.edu.greencity.api.tests.econews.negative.CreateNewsWithArrayResponseTest"/>
-            <class name="com.softserve.edu.greencity.api.tests.econews.negative.CreateNewsWithDetailedResponseTest"/>
-            <class name="com.softserve.edu.greencity.api.tests.econews.negative.CreateNewsWithShortResponseTest"/>
-        </classes>
-    </test>
+
+    <!--
+            <class name="com.softserve.edu.greencity.ui.tests.viewallnews.EcoNewsListViewTests">
+                <methods>
+                    <include name="isItemsDisplayedChronological" />
+                </methods>
+            </class>
+-->
 
 </suite>

--- a/testng.xml
+++ b/testng.xml
@@ -36,8 +36,8 @@
         </classes>
     </test>
 
-    <test name="Create_news_independent" thread-count="4">
-    <!-- Tests that create news, but will not fail if other news is created at the same time
+    <test name="Independent_news_creation" thread-count="4">
+    <!-- Tests that may create news, but will not fail if other news is created at the same time
     (these tests should use switchToSingleNewsPageByParameters, but not ByNumber) -->
         <classes>
             <class name="com.softserve.edu.greencity.ui.tests.createnews.CreateNewsPositiveTest"/>
@@ -49,25 +49,26 @@
             <class name="com.softserve.edu.greencity.ui.tests.comments.CommentCreation"/>
             <class name="com.softserve.edu.greencity.ui.tests.comments.Commentstest"/>
             <class name="com.softserve.edu.greencity.ui.tests.comments.EcoNewsCommentTests"/>
+
+            <class name="com.softserve.edu.greencity.ui.tests.viewallnews.EcoNewsListViewTests"/>
+            <class name="com.softserve.edu.greencity.ui.tests.viewallnews.EcoNewsGridViewTest">
+                <methods>
+                    <exclude name="chronologicalNewsTest" />
+                </methods>
+            </class>
         </classes>
     </test>
 
-    <test name="View_all_news">
+    <test name="Separate_from_news_creation">
 <!--        Should be run separately from the tests that create or delete news. Don't create news by themselves-->
         <classes>
-            <class name="com.softserve.edu.greencity.ui.tests.viewallnews.EcoNewsGridViewTest"/>
-            <class name="com.softserve.edu.greencity.ui.tests.viewallnews.EcoNewsListViewTests"/>
+            <class name="com.softserve.edu.greencity.ui.tests.viewallnews.EcoNewsGridViewTest">
+                <methods>
+                    <include name="chronologicalNewsTest" />
+                </methods>
+            </class>
 <!--            <class name="com.softserve.edu.greencity.ui.tests.viewallnews.EcoNewsPageTest"/>-->
         </classes>
     </test>
-
-
-    <!--
-            <class name="com.softserve.edu.greencity.ui.tests.viewallnews.EcoNewsListViewTests">
-                <methods>
-                    <include name="isItemsDisplayedChronological" />
-                </methods>
-            </class>
--->
 
 </suite>


### PR DESCRIPTION
- Optimised parallel running by editing testsng.xml (now takes ~25 min; run from console `mvn clean test allure:serve`)

- Stabilised tests for parallel running, especially those that create news (searching news by parameters instead of picking the newest one)

- Separated Google login tests from other login tests (should be run without any other browser windows opened)

- Fixed waiting for receiving confirm password email

- Fixed selector in Google account page

- Removed wait for sign in window to appear after successful registration (it was developers' bug, they say, now it shouldn't appear)

- Updated error message on registration by an existing email